### PR TITLE
Add GitHub Actions CI/CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # For full history access
+          
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+          
+      - name: Build with Maven
+        working-directory: ./mcp_server
+        run: ./mvnw clean compile
+        
+      - name: Run tests
+        working-directory: ./mcp_server
+        run: ./mvnw test
+        
+      - name: Package application
+        working-directory: ./mcp_server
+        run: ./mvnw package -DskipTests
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # For full history access
+          
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          
+      - name: Build and package
+        working-directory: ./mcp_server
+        run: ./mvnw clean package
+        
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-jar
+          path: mcp_server/target/*.jar


### PR DESCRIPTION
## Summary
• Add comprehensive GitHub Actions CI/CD pipeline with test and build jobs
• Configure fetch-depth: 0 for full git history access as requested in code review
• Set up Java 21 and Maven caching for optimal build performance

## Test plan
- [x] Verify workflow file syntax and structure
- [ ] Test workflow execution on push to main branch
- [ ] Validate Maven build and test execution
- [ ] Confirm artifact upload functionality

🤖 Generated with [Claude Code](https://claude.ai/code)