### PR TITLE
Pin GitHub Actions to commit SHAs for enhanced security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,18 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0  # For full history access
           
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
         with:
           java-version: '21'
           distribution: 'temurin'
           
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -48,12 +48,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0  # For full history access
           
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -63,7 +63,7 @@ jobs:
         run: ./mvnw clean package
         
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: mcp-server-jar
           path: mcp_server/target/*.jar


### PR DESCRIPTION
- Pin actions/checkout to 692973e (v4.1.7)
- Pin actions/setup-java to b36c23c (v4.4.0)
- Pin actions/cache to 6849a64 (v4.1.2)
- Pin actions/upload-artifact to b4b15b8 (v4.4.3)
- Add version comments for reference and maintainability
- Implement security best practices for supply chain protection

🤖 Generated with [Claude Code](https://claude.ai/code)